### PR TITLE
Use vpc_security_group_ids for instance

### DIFF
--- a/section7-HoL-TF-DynBlocks-Funcs/main.tf
+++ b/section7-HoL-TF-DynBlocks-Funcs/main.tf
@@ -48,6 +48,6 @@ resource "aws_instance" "my-instance" {
   ami             = data.aws_ssm_parameter.ami_id.value
   subnet_id       = module.vpc.public_subnets[0]
   instance_type   = "t3.micro"
-  security_groups = [aws_security_group.my-sg.id]
+  vpc_security_group_ids = [aws_security_group.my-sg.id]
   user_data       = fileexists("script.sh") ? file("script.sh") : null
 }


### PR DESCRIPTION
Per the note in https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance#security_groups, when creating Instances in a VPC, use vpc_security_group_ids instead. Otherwise Terraform plan/apply post the initial apply deletes and recreates the instance.